### PR TITLE
Propozycje poprawek (tym razem powinno być poprawnie)

### DIFF
--- a/lib/pages.py
+++ b/lib/pages.py
@@ -87,7 +87,7 @@ def mobi_header_fields(mobi_content):
     return id, version, title, locations, dict_input, dict_output
 
 
-def get_pages(dirpath, mfile):
+def get_pages(dirpath, mfile, is_verbose):
     file_dec = mfile.decode(sys.getfilesystemencoding())
     with open(os.path.join(dirpath, mfile), 'rb') as f:
         mobi_content = f.read()
@@ -102,7 +102,8 @@ def get_pages(dirpath, mfile):
     asin = find_exth(113, mobi_content)
     dc_lang = find_exth(524, mobi_content)
     if '!DeviceUpgradeLetter!' in asin:
-        print(file_dec + ': Upgrade Letter. Skipping...')
+        if is_verbose:
+            print(file_dec + ': Upgrade Letter. Skipping...')
         return None
     row = [
         asin,


### PR DESCRIPTION
1. Wyłączenie informacji o wykluczeniu plików z folderu "dictionaries" w trybie cichym
2. Wyłączenie informacji o wykluczeniu listów z Amazonu w trybie cichym
3. Wyłączenie informacji o wykluczeniu próbek w formacie KFX w trybie cichym
4. Wyłączenie analizy plików w folderze "attachables" (są tam pomocnicze pliki KFX, których nie warto nawet sprawdzać, bo nie mają jawnej treści ani okładek)