### PR TITLE
Ignore existing covers if size < 1024

### DIFF
--- a/lib/extract_cover_thumbs.py
+++ b/lib/extract_cover_thumbs.py
@@ -390,6 +390,7 @@ def extract_cover_thumbs(is_silent, is_overwrite_pdoc_thumbs,
                     'thumbnail_%s_%s_portrait.jpg' % (asin, doctype)
                 )
                 if (not os.path.isfile(thumbpath) or
+                        (os.path.isfile(thumbpath) and os.path.getsize(thumbpath) < 1024) or  # "image not availabe" stub
                         (is_overwrite_pdoc_thumbs and doctype == 'PDOC') or
                         (is_overwrite_amzn_thumbs and (
                             doctype == 'EBOK' or doctype == 'EBSP'


### PR DESCRIPTION
For a newly added EBOK file, Kindle tries to fetch its cover from Amazon even when the cover already exists in `/system/thumbnails`. The process will replace the existing cover with a ~900 bytes tiny stub image with caption "image not available" in it. Overwriting the stub file with the correct cover again and Kindle will not try to destroy it. (See also: [calibre FAQ](https://manual.calibre-ebook.com/faq.html#covers-for-books-i-send-to-my-e-ink-kindle-show-up-momentarily-and-then-are-replaced-by-a-generic-cover))

This PR makes the code overwrite these stub files, so user does not have to use `--overwrite-amzn-thumbs` flag.